### PR TITLE
Fix mapUserToObject()

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\Keycloak;
 
+use Illuminate\Support\Arr;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
@@ -61,10 +62,10 @@ class Provider extends AbstractProvider
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user)->map([
-            'id'        => Arr::get($user['sub']),
-            'nickname'  => Arr::get($user['preferred_username']),
-            'name'      => Arr::get($user['given_name']),
-            'email'     => Arr::get($user['email']),
+            'id'        => Arr::get($user, 'sub'),
+            'nickname'  => Arr::get($user, 'preferred_username'),
+            'name'      => Arr::get($user, 'given_name'),
+            'email'     => Arr::get($user, 'email'),
         ]);
     }
 


### PR DESCRIPTION
Fix `Arr::get()` usage.

Actually this provider was not working. 

![image](https://user-images.githubusercontent.com/118955/82767665-97f72800-9dff-11ea-8169-be420c978d7f.png)
