### PR TITLE
Retrieve user roles

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -7,6 +7,9 @@ use Illuminate\Support\Arr;
 use SocialiteProviders\Manager\Exception\InvalidArgumentException;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+use Illuminate\Support\Facades\Http;
 
 class Provider extends AbstractProvider
 {
@@ -21,12 +24,12 @@ class Provider extends AbstractProvider
      */
     public static function additionalConfigKeys()
     {
-        return ['base_url', 'realms'];
+        return ['base_url', 'realms', 'public_key', 'algorithm'];
     }
 
     protected function getBaseUrl()
     {
-        return rtrim(rtrim($this->getConfig('base_url'), '/').'/realms/'.$this->getConfig('realms', 'master'), '/');
+        return rtrim(rtrim($this->getConfig('base_url'), '/') . '/realms/' . $this->getConfig('realms', 'master'), '/');
     }
 
     /**
@@ -34,7 +37,7 @@ class Provider extends AbstractProvider
      */
     protected function getAuthUrl($state)
     {
-        return $this->buildAuthUrlFromBase($this->getBaseUrl().'/protocol/openid-connect/auth', $state);
+        return $this->buildAuthUrlFromBase($this->getBaseUrl() . '/protocol/openid-connect/auth', $state);
     }
 
     /**
@@ -42,7 +45,7 @@ class Provider extends AbstractProvider
      */
     protected function getTokenUrl()
     {
-        return $this->getBaseUrl().'/protocol/openid-connect/token';
+        return $this->getBaseUrl() . '/protocol/openid-connect/token';
     }
 
     /**
@@ -50,9 +53,9 @@ class Provider extends AbstractProvider
      */
     protected function getUserByToken($token)
     {
-        $response = $this->getHttpClient()->get($this->getBaseUrl().'/protocol/openid-connect/userinfo', [
+        $response = $this->getHttpClient()->get($this->getBaseUrl() . '/protocol/openid-connect/userinfo', [
             RequestOptions::HEADERS => [
-                'Authorization' => 'Bearer '.$token,
+                'Authorization' => 'Bearer ' . $token,
             ],
         ]);
 
@@ -97,7 +100,7 @@ class Provider extends AbstractProvider
      */
     public function getLogoutUrl(?string $redirectUri = null, ?string $clientId = null, ?string $idTokenHint = null, ...$additionalParameters): string
     {
-        $logoutUrl = $this->getBaseUrl().'/protocol/openid-connect/logout';
+        $logoutUrl = $this->getBaseUrl() . '/protocol/openid-connect/logout';
 
         // Keycloak v18+ or before
         if ($redirectUri === null) {
@@ -106,22 +109,22 @@ class Provider extends AbstractProvider
 
         // Before Keycloak v18
         if ($clientId === null && $idTokenHint === null) {
-            return $logoutUrl.'?redirect_uri='.urlencode($redirectUri);
+            return $logoutUrl . '?redirect_uri=' . urlencode($redirectUri);
         }
 
         // Keycloak v18+
         // https://www.keycloak.org/docs/18.0/securing_apps/index.html#logout
         // https://openid.net/specs/openid-connect-rpinitiated-1_0.html
-        $logoutUrl .= '?post_logout_redirect_uri='.urlencode($redirectUri);
+        $logoutUrl .= '?post_logout_redirect_uri=' . urlencode($redirectUri);
 
         // Either clientId or idTokenHint
         // is required for the post redirect to work.
         if ($clientId !== null) {
-            $logoutUrl .= '&client_id='.urlencode($clientId);
+            $logoutUrl .= '&client_id=' . urlencode($clientId);
         }
 
         if ($idTokenHint !== null) {
-            $logoutUrl .= '&id_token_hint='.urlencode($idTokenHint);
+            $logoutUrl .= '&id_token_hint=' . urlencode($idTokenHint);
         }
 
         foreach ($additionalParameters as $parameter) {
@@ -132,9 +135,107 @@ class Provider extends AbstractProvider
             $parameterKey = array_keys($parameter)[0];
             $parameterValue = array_values($parameter)[0];
 
-            $logoutUrl .= "&{$parameterKey}=".urlencode($parameterValue);
+            $logoutUrl .= "&{$parameterKey}=" . urlencode($parameterValue);
         }
 
         return $logoutUrl;
+    }
+
+    /**
+     * Get the public key of the realm
+     *
+     * @param string $algorithm
+     * @param string $access_token
+     * @return string|null
+     */
+    public function getKey(string $algorithm, string $access_token): ?string
+    {
+        try {
+            $response = $this->getHttpClient()->get(
+                $this->getConfig('base_url') . '/admin/realms/' . $this->getConfig('realms') . '/keys',
+                [
+                    RequestOptions::HEADERS => [
+                        'Authorization' => 'Bearer ' . $access_token,
+                    ],
+                ]
+            );
+
+            $responseBody = json_decode((string) $response->getBody(), true);
+
+            /**
+             * @var array<string,string>
+             */
+            $algorithms = $responseBody['active'];
+
+            if (!array_key_exists($algorithm, $algorithms)) {
+                return null;
+            }
+
+            /**
+             * @var array<array<string,string>>
+             */
+            $keys = $responseBody['keys'];
+
+            $key = array_values(
+                array_filter(
+                    $keys,
+                    fn (array $key) => $key['algorithm'] === $algorithm
+                )
+            );
+
+            return array_key_exists('publicKey', $key[0]) ? $key[0]['publicKey'] : null;
+        } catch (\Throwable $th) {
+            return null;
+        }
+    }
+
+    /**
+     * Decode token to retrieve user roles
+     *
+     * @param string $access_token
+     * @return array<string, string[]>
+     */
+    public function getUserRoles(string $access_token, ?string $client_id = null): array
+    {
+        $publickKey = $this->getConfig('public_key');
+        $algorithm = $this->getConfig('algorithm');
+
+        if (!$publickKey && !$algorithm) {
+            return [];
+        }
+
+        if (!$publickKey) {
+            $rawPublicKey = $this->getKey(algorithm: $algorithm, access_token: $access_token);
+
+            if (!$rawPublicKey) {
+                return [];
+            }
+
+            $publickKey = preg_replace(
+                '/(<br \/>)/m',
+                '',
+                nl2br("-----BEGIN PUBLIC KEY-----\n{$rawPublicKey}\n-----END PUBLIC KEY-----")
+            );
+        }
+
+        try {
+            $decoded = (array) JWT::decode($access_token, new Key($publickKey, $algorithm));
+
+            $ressourceAccess = (array) $decoded['resource_access'];
+
+            if ($client_id) {
+                return $ressourceAccess[$client_id]->roles;
+            }
+
+            $roles = [];
+
+            foreach ($ressourceAccess as $clientId => $clientRoles) {
+                $roles[$clientId] = $clientRoles->roles;
+            }
+
+            return $roles;
+        } catch (\Throwable $th) {
+            return [];
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "~4.0",
+        "firebase/php-jwt": "^6.8"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Most of the time, when I work with Keycloak, I need to protect some routes or even some parts of my views based on the roles associated to the user on keycloak.

But, unfortunately, we don't have any method or even function to retrieve directly user roles in this package, unless we make some request to keycloak.

I thought that it can be hepful for the community to have such method so I write it. It just decode the access_token to retrieve the user roles.

To decode the token I use the `firebase/php-jwt` package. But if you don't want more dependency, I can do it by my own.

To decode the token, I use also the realm's public key which the user can provide via the env variable `KEYCLOAK_PUBLIC_KEY`. But it's optional actually. So, when it's not set, I retrieve it by my own.

I hope that you will appreciate it and please let me know if you find any issue or suggestion on my code.

Regards